### PR TITLE
add options to set name/description for "cloudctl ip static"

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -57,6 +57,10 @@ func init() {
 	ipListCmd.Flags().StringP("prefix", "", "", "prefx to filter [optional]")
 	ipListCmd.Flags().StringP("machineid", "", "", "machineid to filter [optional]")
 	ipListCmd.Flags().StringP("network", "", "", "network to filter [optional]")
+
+	ipStaticCmd.Flags().StringP("name", "", "", "set name of the ip address [optional]")
+	ipStaticCmd.Flags().StringP("description", "", "", "set description of the ip address [optional]")
+
 	ipListCmd.RegisterFlagCompletionFunc("project", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return projectListCompletion()
 	})
@@ -108,6 +112,13 @@ func ipStatic(args []string) error {
 		Ipaddress: &ipAddress,
 		Type:      "static",
 	}
+	if helper.ViperString("name") != nil {
+		iur.Name = *helper.ViperString("name")
+	}
+	if helper.ViperString("description") != nil {
+		iur.Description = *helper.ViperString("description")
+	}
+
 	params.SetBody(iur)
 	resp, err := cloud.IP.UpdateIP(params, cloud.Auth)
 	if err != nil {


### PR DESCRIPTION
adds `--name --description` options to `cloudctl ip static`

```
Usage:
  cloudctl ip static <ip> [flags]

Flags:
      --description string   set description of the ip address [optional]
  -h, --help                 help for static
      --name string          set name of the ip address [optional]

```
```
$ cloudctl ip static 212.34.83.5 --name mwentest --description "test ip static"
IP              TYPE    NAME            NETWORK         PROJECT                                 TAGS
212.34.83.5     static  mwentest        internet        cd4eac58-46a5-4a31-b59f-2ec207baa817    service:ded51942-192b-4daf-b5b1-622b072cc58b/default/echoserver

$ cloudctl ip ls -o wide| grep 212.34.83.5
212.34.83.5     static          mwentest                                                        test ip static  internet                                cd4eac58-46a5-4a31-b59f-2ec207baa817    cluster.metal-stack.io/id/namespace/service=ded51942-192b-4daf-b5b1-622b072cc58b/default/echoserver
```