### PR TITLE
fix cri output for containerd clusters

### DIFF
--- a/cmd/output/shootprinter.go
+++ b/cmd/output/shootprinter.go
@@ -215,7 +215,7 @@ func shootData(shoot *models.V1ClusterResponse, withIssues bool) ([]string, []st
 		privileged = fmt.Sprintf("%t", *shoot.Kubernetes.AllowPrivilegedContainers)
 	}
 
-	runtimes := []string{"docker"}
+	runtimes := []string{}
 	autoScaleMin := int32(0)
 	autoScaleMax := int32(0)
 	for _, w := range shoot.Workers {
@@ -223,6 +223,8 @@ func shootData(shoot *models.V1ClusterResponse, withIssues bool) ([]string, []st
 		autoScaleMax += *w.Maximum
 		if w.CRI != nil && *w.CRI != "" {
 			runtimes = append(runtimes, *w.CRI)
+		} else {
+			runtimes = append(runtimes, "docker")
 		}
 	}
 	currentMachines := "x"


### PR DESCRIPTION
For clusters with CRI=containerd, the RUNTIME contains an additional wrong `docker`

```
UID                                     NAME            VERSION PARTITION       DOMAIN                                  OPERATION       PROGRESS                API     CONTROL NODES   SYSTEM  SIZE    AGE     PURPOSE PRIVILEGED      RUNTIME         FIREWALL                        EGRESS IPS 
9529c143-b78d-4ec4-a041-3b86626126cc    mycluster1      1.18.12 stg-kkw701      mycluster1.p5mlcn.cluster.fits.cloud    Succeeded       100% [Reconcile]        True    True    True    True    1≤1≤1   5h 33m  prod    false           docker          firewall-ubuntu-2.0.20201126              
                                                                                                                                                                                                                                        containerd                       

```

with this fix:

```
UID                                     NAME            VERSION PARTITION       DOMAIN                                  OPERATION       PROGRESS                API     CONTROL NODES   SYSTEM  SIZE    AGE     PURPOSE PRIVILEGED      RUNTIME         FIREWALL                        EGRESS IPS 
9529c143-b78d-4ec4-a041-3b86626126cc    mycluster1      1.18.12 stg-kkw701      mycluster1.p5mlcn.cluster.fits.cloud    Succeeded       100% [Reconcile]        True    True    True    True    1≤1≤1   5h 33m  prod    false           containerd      firewall-ubuntu-2.0.20201126  

```