### PR TITLE
Fix invalid JSON output for cluster machine ls and cluster logs.

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -920,6 +920,11 @@ func clusterMachines(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if printer.Type() != "table" {
+		return printer.Print(shoot.Payload)
+	}
+
 	fmt.Println("Cluster:")
 	printer.Print(shoot.Payload)
 

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -957,6 +957,19 @@ func clusterLogs(args []string) error {
 		lastErrors = shoot.Payload.Status.LastErrors
 	}
 
+	if printer.Type() != "table" {
+		type s struct {
+			Conditions    []*models.V1beta1Condition
+			LastOperation *models.V1beta1LastOperation
+			LastErrors    []*models.V1beta1LastError
+		}
+		return printer.Print(s{
+			Conditions:    conditions,
+			LastOperation: lastOperation,
+			LastErrors:    lastErrors,
+		})
+	}
+
 	fmt.Println("Conditions:")
 	err = printer.Print(conditions)
 	if err != nil {

--- a/cmd/output/printer.go
+++ b/cmd/output/printer.go
@@ -18,6 +18,7 @@ type (
 	// Printer main Interface for implementations which spits out to stdout
 	Printer interface {
 		Print(data interface{}) error
+		Type() string
 	}
 	TablePrinter struct {
 		table       *tablewriter.Table
@@ -170,6 +171,10 @@ func newTablePrinter(format, order string, noHeaders bool, template *template.Te
 	return tp
 }
 
+func (t TablePrinter) Type() string {
+	return "table"
+}
+
 // Print a model in a human readable table
 func (t TablePrinter) Print(data interface{}) error {
 	switch d := data.(type) {
@@ -256,6 +261,10 @@ func (j JSONPrinter) Print(data interface{}) error {
 	return nil
 }
 
+func (j JSONPrinter) Type() string {
+	return "json"
+}
+
 // Print a model in yaml format
 func (y YAMLPrinter) Print(data interface{}) error {
 	yml, err := yaml.Marshal(data)
@@ -264,4 +273,8 @@ func (y YAMLPrinter) Print(data interface{}) error {
 	}
 	fmt.Printf("%s\n", string(yml))
 	return nil
+}
+
+func (y YAMLPrinter) Type() string {
+	return "yaml"
 }


### PR DESCRIPTION
If somebody uses `-o json` or `-o yaml` it is expected that the output of cloudctl returns JSON / YAML. At the moment, though, we return multiple objects for `cluster machine ls` and `cluster logs` containing headings in between the output, which makes the output hard for users to process.

This PR prints more original payload without the additional formatting that is applied for the table printer output.