### PR TITLE
Don't clean IP tags when running ip static command.

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -150,7 +150,6 @@ func ipStatic(args []string) error {
 	iur := &models.V1IPUpdateRequest{
 		Ipaddress: &ipAddress,
 		Type:      "static",
-		Tags:      []string{},
 	}
 	if helper.ViperString("name") != nil {
 		iur.Name = *helper.ViperString("name")


### PR DESCRIPTION
The metal-ccm considers the tag of the IP for calculating the MetalLB address pools. Defining the "statified IP" in the service's LoadBalancerIP field will add the tag back though.