### PR TITLE
added version cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ api/client
 api/models
 bin
 .idea
+cloudctl

--- a/cmd/output/printer.go
+++ b/cmd/output/printer.go
@@ -282,6 +282,8 @@ func (t TablePrinter) Print(data interface{}) error {
 		S3PartitionTablePrinter{t}.Print(d)
 	case *api.Contexts:
 		ContextPrinter{t}.Print(d)
+	case api.Version:
+		YAMLPrinter{}.Print(d)
 	default:
 		return fmt.Errorf("unknown table printer for type: %T", d)
 	}
@@ -308,7 +310,7 @@ func (y YAMLPrinter) Print(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal to yaml:%w", err)
 	}
-	fmt.Printf("%s\n", string(yml))
+	fmt.Printf("%s", string(yml))
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fi-ts/cloud-go/api/client"
 	output "github.com/fi-ts/cloudctl/cmd/output"
 	"github.com/fi-ts/cloudctl/pkg/api"
-	"github.com/metal-stack/v"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,10 +40,9 @@ var (
 	}
 
 	rootCmd = &cobra.Command{
-		Use:     programName,
-		Short:   "a cli to manage cloud entities.",
-		Long:    "with cloudctl you can manage kubernetes cluster, view networks et.al.",
-		Version: v.V.String(),
+		Use:   programName,
+		Short: "a cli to manage cloud entities.",
+		Long:  "with cloudctl you can manage kubernetes cluster, view networks et.al.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			initPrinter()
 		},
@@ -88,6 +86,7 @@ func init() {
 	rootCmd.AddCommand(tenantCmd)
 	rootCmd.AddCommand(contextCmd)
 	rootCmd.AddCommand(s3Cmd)
+	rootCmd.AddCommand(versionCmd)
 
 	rootCmd.AddCommand(completionCmd)
 	completionCmd.AddCommand(bashCompletionCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fi-ts/cloudctl/pkg/api"
+	"github.com/metal-stack/v"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print the client and server version information",
+	Long:  "print the client and server version information",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v := api.Version{
+			Client: v.V.String(),
+		}
+
+		resp, err := cloud.Version.Info(nil, nil)
+		if err == nil {
+			v.Server = resp.Payload
+		}
+
+		if err2 := printer.Print(v); err2 != nil {
+			return err2
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get server info: %w", err)
+		}
+		return nil
+	},
+	PreRun: bindPFlags,
+}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/metal-stack/metal-lib/jwt/sec"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"time"
 )
 
 var whoamiCmd = &cobra.Command{

--- a/pkg/api/version.go
+++ b/pkg/api/version.go
@@ -1,0 +1,10 @@
+package api
+
+import (
+	cloudmodels "github.com/fi-ts/cloud-go/api/models"
+)
+
+type Version struct {
+	Client string                   `yaml:"client"`
+	Server *cloudmodels.RestVersion `yaml:"server,omitempty"`
+}


### PR DESCRIPTION
cc @majst01 
Output looks similar to `metalctl version` command:
If server is available:
```
client: 1.1, go1.16.5
server:
    builddate: "2021-03-29T11:30:07Z"
    gitsha1: e843d254
    name: metal-api
    revision: tags/v0.14.1-0-ge843d25
    version: v0.14.1
```

If not available:
```
client: 1.1, go1.16.5
Error: failed to get server info: Get "http://localhost:8080/cloud/v1/version": dial tcp 127.0.0.1:8080: connect: connection refused
```