### PR TITLE
Fix interface conversion during pg edit

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -520,19 +520,19 @@ func postgresEdit(args []string) error {
 }
 
 func readPostgresUpdateRequests(filename string) ([]models.V1PostgresUpdateRequest, error) {
-	var pcrs []models.V1PostgresUpdateRequest
-	var pcr models.V1PostgresCreateRequest
-	err := helper.ReadFrom(filename, &pcr, func(data interface{}) {
+	var purs []models.V1PostgresUpdateRequest
+	var pur models.V1PostgresUpdateRequest
+	err := helper.ReadFrom(filename, &pur, func(data interface{}) {
 		doc := data.(*models.V1PostgresUpdateRequest)
-		pcrs = append(pcrs, *doc)
+		purs = append(purs, *doc)
 	})
 	if err != nil {
-		return pcrs, err
+		return purs, err
 	}
-	if len(pcrs) != 1 {
-		return pcrs, fmt.Errorf("postgres update error more or less than one postgres given:%d", len(pcrs))
+	if len(purs) != 1 {
+		return purs, fmt.Errorf("postgres update error more or less than one postgres given:%d", len(purs))
 	}
-	return pcrs, nil
+	return purs, nil
 }
 
 func postgresFind() error {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/viper v1.8.0
+	github.com/spf13/viper v1.8.1
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -853,6 +853,8 @@ github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfD
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.0 h1:QRwDgoG8xX+kp69di68D+YYTCWfYEckbZRfUlEIAal0=
 github.com/spf13/viper v1.8.0/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
+github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
```
cloudctl postgres edit ade2ed7b-3bdd-4863-b234-edbdbf43a89c
panic: interface conversion: interface {} is *models.V1PostgresCreateRequest, not *models.V1PostgresUpdateRequest

goroutine 1 [running]:
github.com/fi-ts/cloudctl/cmd.readPostgresUpdateRequests.func1(0x24994e0, 0xc000724000)
	/work/cmd/postgres.go:526 +0x166
github.com/fi-ts/cloudctl/cmd/helper.ReadFrom(0xc0007ea140, 0x47, 0x24994e0, 0xc000724000, 0xc00015bb58, 0xb, 0xc)
	/work/cmd/helper/helper.go:125 +0x1d9
github.com/fi-ts/cloudctl/cmd.readPostgresUpdateRequests(0xc0007ea140, 0x47, 0xc0000a2168, 0x0, 0x0, 0x0, 0x0)
	/work/cmd/postgres.go:525 +0xa5
github.com/fi-ts/cloudctl/cmd.postgresEdit.func2(0xc0007ea140, 0x47, 0x0, 0x1)
	/work/cmd/postgres.go:504 +0x3c
github.com/fi-ts/cloudctl/cmd/helper.Edit(0x76b4937, 0x24, 0x2677a70, 0x2677a78, 0x0, 0x0)
	/work/cmd/helper/helper.go:158 +0x2ee
github.com/fi-ts/cloudctl/cmd.postgresEdit(0xc00009da50, 0x1, 0x1, 0x0, 0x0)
	/work/cmd/postgres.go:519 +0xae
github.com/fi-ts/cloudctl/cmd.glob..func45(0x3294300, 0xc00009da50, 0x1, 0x1, 0x0, 0x0)
	/work/cmd/postgres.go:89 +0x3f
github.com/spf13/cobra.(*Command).execute(0x3294300, 0xc00009da20, 0x1, 0x1, 0x3294300, 0xc00009da20)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x3297780, 0x60, 0x8100a68, 0x60)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/fi-ts/cloudctl/cmd.Execute()
	/work/cmd/root.go:57 +0x31
main.main()
	/work/main.go:8 +0x25

```