### PR TITLE
enable dynamic completion based on previous selected cluster

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -314,10 +314,10 @@ func init() {
 		return firewallControllerVersionListCompletion()
 	})
 	clusterCreateCmd.RegisterFlagCompletionFunc("purpose", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"production", "development", "evaluation"}, cobra.ShellCompDirectiveDefault
+		return []string{"production", "development", "evaluation"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	clusterCreateCmd.RegisterFlagCompletionFunc("cri", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"docker", "containerd"}, cobra.ShellCompDirectiveDefault
+		return []string{"docker", "containerd"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	// Cluster list --------------------------------------------------------------------
@@ -375,39 +375,34 @@ func init() {
 		return machineImageListCompletion()
 	})
 	clusterUpdateCmd.RegisterFlagCompletionFunc("purpose", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"production", "development", "evaluation"}, cobra.ShellCompDirectiveDefault
+		return []string{"production", "development", "evaluation"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	clusterMachineSSHCmd.Flags().String("machineid", "", "machine to connect to.")
 	clusterMachineSSHCmd.MarkFlagRequired("machineid")
 	clusterMachineSSHCmd.RegisterFlagCompletionFunc("machineid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// FIXME howto implement flag based completion for a already given clusterid
-		return clusterMachineListCompletion("123")
+		return clusterMachineListCompletion(args, false)
 	})
 	clusterMachineConsoleCmd.Flags().String("machineid", "", "machine to connect to.")
 	clusterMachineConsoleCmd.MarkFlagRequired("machineid")
 	clusterMachineConsoleCmd.RegisterFlagCompletionFunc("machineid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// FIXME howto implement flag based completion for a already given clusterid
-		return clusterMachineListCompletion("123")
+		return clusterMachineListCompletion(args, true)
 	})
 	clusterMachineResetCmd.Flags().String("machineid", "", "machine to reset.")
 	clusterMachineResetCmd.MarkFlagRequired("machineid")
 	clusterMachineResetCmd.RegisterFlagCompletionFunc("machineid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// FIXME howto implement flag based completion for a already given clusterid
-		return clusterMachineListCompletion("123")
+		return clusterMachineListCompletion(args, true)
 	})
 	clusterMachineCycleCmd.Flags().String("machineid", "", "machine to reset.")
 	clusterMachineCycleCmd.MarkFlagRequired("machineid")
 	clusterMachineCycleCmd.RegisterFlagCompletionFunc("machineid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// FIXME howto implement flag based completion for a already given clusterid
-		return clusterMachineListCompletion("123")
+		return clusterMachineListCompletion(args, true)
 	})
 	clusterMachineReinstallCmd.Flags().String("machineid", "", "machine to reinstall.")
 	clusterMachineReinstallCmd.Flags().String("machineimage", "", "image to reinstall (optional).")
 	clusterMachineReinstallCmd.MarkFlagRequired("machineid")
 	clusterMachineReinstallCmd.RegisterFlagCompletionFunc("machineid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// FIXME howto implement flag based completion for a already given clusterid
-		return clusterMachineListCompletion("123")
+		return clusterMachineListCompletion(args, true)
 	})
 	clusterMachineCmd.AddCommand(clusterMachineListCmd)
 	clusterMachineCmd.AddCommand(clusterMachineSSHCmd)

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -296,7 +296,7 @@ func init() {
 
 	postgresConnectionStringCmd.Flags().StringP("type", "", "psql", "the type of the connectionstring to create, can be one of psql|jdbc")
 	err = postgresConnectionStringCmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"jdbc", "psql"}, cobra.ShellCompDirectiveDefault
+		return []string{"jdbc", "psql"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
It was not possible to get a completion to certain commands which require the already selected  cluster as input, e.g.

`cloudctl cluster machine console 8fef639c-bbe4-4c6f-9656-617dc4a4efd8 --machineid <tab><tab>` did not return the machines attached to this cluster.

Now:
```
cloudctl cluster machine console 8fef639c-bbe4-4c6f-9656-617dc4a4efd8 --machineid 00000000-0000-0000-0000-ac1f6b7b
00000000-0000-0000-0000-ac1f6b7b77c8  (shoot--test--fra-equ01-firewall-c9d01)              00000000-0000-0000-0000-ac1f6b7bed30  (shoot--test--fra-equ01-default-worker-5f9b5-ltk9g)
```



Also add descriptions to the completion suggestions that makes decision more simple:

```
cloudctl cluster logs 
256ca952-0c0f-4d62-aabf-da4e6f3e9183  (s3-test-01)  5c985fdf-6c26-4cf3-96a0-8de97d9ffeee  (behinddmz)   8fef639c-bbe4-4c6f-9656-617dc4a4efd8  (fra-equ01)   da95735d-da26-4909-aa6b-beb920e85680  (inttest0)    e0ab89d8-c087-4c5a-9e86-7656a2371c24  (dmz)
```
And:

```
cloudctl cluster create --project 
00000000-0000-0000-0000-000000000000  (fits/metal-system)           580187a1-49ae-4dca-aa92-c33695737d95  (fits/pgaas)                  b5f26a3b-9a4d-48db-a6b3-d1dd4ac4abec  (fits/stefan)
00000000-0000-0000-0000-000000000001  (fits/gardener-seeds)         5820c4e7-fbd4-4e4b-a40b-2b83eb34bbe1  (fits/s3-test)                b621eb99-4888-4911-93fc-95854fc030e8  (fits/philipp
```

Additionally completion on files in the cwd is disabled as well.