### PR TITLE
README: add installation with the nix package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ chmod +x cloudctl-darwin-amd64
 sudo mv cloudctl-darwin-amd64 /usr/local/bin/cloudctl
 ```
 
+### Usage with Nix on Linux or MacOS
+
+`fits-cloudctl` is packaged in [nixpkgs](https://github.com/NixOS/nixpkgs) and
+can be installed using the [Nix Package Manager](https://nixos.org/) on Linux,
+MacOS and NixOS.
+
+```bash
+$ nix-shell -p fits-cloudctl
+```
+
+The package can also be installed eg. with 'nix-env -i fits-cloudctl'.
+
 ### Installation on Windows
 
 ```bash
@@ -108,7 +120,7 @@ contexts:
     client_secret: my-secret
 ```
 
-If you must specify special scopes for your issuer, you can use `custom_scopes`: 
+If you must specify special scopes for your issuer, you can use `custom_scopes`:
 ```yaml
 contexts:
   prod:


### PR DESCRIPTION
`cloudctl` is now packaged as [nix](https://nixos.org) package. Added description to `README.md`.

see https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/fits-cloudctl/default.nix