### PR TITLE
Fix Postgres Promote/Demote Calls

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -468,9 +468,11 @@ func (c *config) postgresPromoteToPrimary(args []string) error {
 
 	// copy the (minimum) current config
 	body := &models.V1PostgresUpdateRequest{
-		ProjectID:  current.ProjectID,
-		ID:         current.ID,
-		Connection: current.Connection,
+		ProjectID:      current.ProjectID,
+		ID:             current.ID,
+		Connection:     current.Connection,
+		AuditLogs:      current.AuditLogs,
+		PostgresParams: current.PostgresParams,
 	}
 
 	// abort if there is no configured connection
@@ -510,9 +512,11 @@ func (c *config) postgresDemoteToStandby(args []string) error {
 
 	// copy the (minimum) current config
 	body := &models.V1PostgresUpdateRequest{
-		ProjectID:  current.ProjectID,
-		ID:         current.ID,
-		Connection: current.Connection,
+		ProjectID:      current.ProjectID,
+		ID:             current.ID,
+		Connection:     current.Connection,
+		AuditLogs:      current.AuditLogs,
+		PostgresParams: current.PostgresParams,
 	}
 
 	// abort if there is no configured connection


### PR DESCRIPTION
For whatever reaseon, we decided not to use nillable values for some params in the `V1PostgresUpdateRequest`. Those need to be send to the API in order to prevent them being overwritten with the default value.