### PR TITLE
validate workergroup name before removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ api/models
 bin
 .idea
 cloudctl
+.vscode

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -942,6 +942,10 @@ func (c *config) updateCluster(args []string) error {
 		}
 
 		if removeworkergroup {
+			if worker == nil {
+				return fmt.Errorf("worker group %s not found", workergroupname)
+			}
+
 			fmt.Println("WARNING. Removing a worker group cannot be undone and causes the loss of local data on the deleted nodes.")
 			err = helper.Prompt("Are you sure? (y/n)", "y")
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func newRootCmd() *cobra.Command {
 	must(viper.BindPFlags(rootCmd.Flags()))
 	must(viper.BindPFlags(rootCmd.PersistentFlags()))
 
-	cfg := getConfig(rootCmd, name)
+	cfg := getConfig(name)
 
 	rootCmd.AddCommand(newClusterCmd(cfg))
 	rootCmd.AddCommand(newDashboardCmd(cfg))
@@ -101,7 +101,7 @@ type config struct {
 	log         *zap.SugaredLogger
 }
 
-func getConfig(cmd *cobra.Command, name string) *config {
+func getConfig(name string) *config {
 	viper.SetEnvPrefix(strings.ToUpper(name))
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
prevents segfault with invalid workergroup name:

```
$ cloudctl  cluster update 4e21f74e-8134-417f-b474-785332e58b3c --workergroup blafasel --remove-workergroup 
WARNING. Removing a worker group cannot be undone and causes the loss of local data on the deleted nodes.
Are you sure? (y/n) y
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x117369a]

goroutine 1 [running]:
github.com/fi-ts/cloudctl/cmd.(*config).updateCluster(0xc000516240, {0xc00083a1c0, 0x1, 0x4})
        /work/cmd/cluster.go:954 +0x1dba

```