### PR TITLE
For build date use Go-compatible RFC3339 date format, fixes `update check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := cloudctl-$(GOOS)-$(GOARCH)
 
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --all)
-BUILDDATE := $(shell date --rfc-3339=seconds)
+BUILDDATE := $(shell date --iso-8601=seconds) # this format is parsable with Go RFC3339
 VERSION := $(or ${VERSION},$(shell git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD))
 
 ifeq ($(CGO_ENABLED),1)


### PR DESCRIPTION
Unfortunately, GNU date produces a date with the `--rfc-3339=seconds` that Golang cannot parse with it's RFC3339 format definition.

Instead we need to use the `--iso-8601=seconds` flag, which is at least parsable with Go.

Here I demonstrate the behavior: https://go.dev/play/p/FSXBzJcqpUA

There is also a good blog article talking about this issue and where it comes from: https://utcc.utoronto.ca/~cks/space/blog/unix/GNUDateAndRFC3339

Other repositories where we need to apply this change to:

- [ ] metal-stack/metalctl (important as `update check` is now broken)
- [ ] metal-stack/backup-restore-sidecar
- [ ] metal-stack/metal-api
- [ ] metal-stack/masterdata-api

The bug was introduced in this commit: https://github.com/fi-ts/cloudctl/pull/248/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52

Closes #258.