### PR TITLE
Second fix on date format: Remove whitespace that came from comment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ BINARY := cloudctl-$(GOOS)-$(GOARCH)
 
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --all)
-BUILDDATE := $(shell date --iso-8601=seconds) # this format is parsable with Go RFC3339
+# gnu date format iso-8601 is parsable with Go RFC3339
+BUILDDATE := $(shell date --iso-8601=seconds)
 VERSION := $(or ${VERSION},$(shell git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD))
 
 ifeq ($(CGO_ENABLED),1)


### PR DESCRIPTION
Last release results into:

```
❯ ~/Downloads/cloudctl update check 
checksum:7ad8446e9de3edeebdc8eb2d5d9a3351
Error: parsing time "2023-09-13T09:02:01+00:00 ": extra text: " "
```

Because the comment in the Makefile added a whitespace character to the end of the date. 🙄