### PR TITLE
add possible reconcile operations to help output

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -480,7 +480,7 @@ func newClusterCmd(c *config) *cobra.Command {
 	clusterMachineCmd.AddCommand(clusterMachineReinstallCmd)
 	clusterMachineCmd.AddCommand(clusterMachinePackagesCmd)
 
-	clusterReconcileCmd.Flags().String("operation", models.V1ClusterReconcileRequestOperationReconcile, "Executes a cluster \"reconcile\" operation.")
+	clusterReconcileCmd.Flags().String("operation", models.V1ClusterReconcileRequestOperationReconcile, fmt.Sprintf("Executes a cluster \"reconcile\" operation, can be one of %s.", strings.Join(completion.ClusterReconcileOperations, "|")))
 	must(clusterReconcileCmd.RegisterFlagCompletionFunc("operation", c.comp.ClusterReconcileOperationCompletion))
 
 	clusterIssuesCmd.Flags().String("id", "", "show clusters of given id")

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -17,7 +17,13 @@ import (
 )
 
 var (
-	ClusterPurposes     = []string{"production", "development", "evaluation", "infrastructure"}
+	ClusterPurposes            = []string{"production", "development", "evaluation", "infrastructure"}
+	ClusterReconcileOperations = []string{
+		models.V1ClusterReconcileRequestOperationReconcile,
+		models.V1ClusterReconcileRequestOperationRetry,
+		models.V1ClusterReconcileRequestOperationMaintain,
+		models.V1ClusterReconcileRequestOperationRotateDashSSHDashKeypair,
+	}
 	PodSecurityDefaults = []string{
 		models.V1KubernetesDefaultPodSecurityStandardRestricted,
 		models.V1KubernetesDefaultPodSecurityStandardBaseline,


### PR DESCRIPTION
```default
Usage:
  cloudctl cluster reconcile <clusterid> [flags]

Flags:
  -h, --help               help for reconcile
      --operation string   Executes a cluster "reconcile" operation, can be one of reconcile|retry|maintain|rotate-ssh-keypair. (default "reconcile")
```

closes https://github.com/fi-ts/cloudctl/issues/268