### PR TITLE
skip printing empty rows in tablePrinter

### DIFF
--- a/cmd/output/printer.go
+++ b/cmd/output/printer.go
@@ -76,6 +76,9 @@ func (t *tablePrinter) render() {
 			if len(row) < 1 {
 				continue
 			}
+			if len(row[0]) == 0 {
+				continue
+			}
 			fmt.Println(row[0])
 		}
 		t.shortData = [][]string{}


### PR DESCRIPTION
Nicer output when using conditionals in template output.

Before:
```
$ cloudctl cluster ls -o template --template '{{ if eq .Networking.Type "cilium" }}{{ .Name }}{{end}}'






cilium

```

With this PR:
```
$ cloudctl ls -o template --template '{{ if eq .Networking.Type "cilium" }}{{ .Name }}{{end}}'
cilium
```