### PR TITLE
Add transition code to allow migration to genericcli table printer

### DIFF
--- a/cmd/printers.go
+++ b/cmd/printers.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/fatih/color"
-	"github.com/fi-ts/cloudctl/cmd/output"
+	"github.com/fi-ts/cloudctl/cmd/tableprinters"
 	"github.com/metal-stack/metal-lib/pkg/genericcli/printers"
 	"github.com/spf13/viper"
 )
@@ -19,7 +19,18 @@ func newPrinterFromCLI(out io.Writer) printers.Printer {
 	case "json":
 		printer = printers.NewJSONPrinter().WithOut(out)
 	case "table", "wide", "markdown":
-		printer = output.New()
+		tp := tableprinters.New()
+
+		tablePrinter := printers.NewTablePrinter(&printers.TablePrinterConfig{
+			ToHeaderAndRows: tp.ToHeaderAndRows,
+			Wide:            format == "wide",
+			Markdown:        format == "markdown",
+			NoHeaders:       viper.GetBool("no-headers"),
+		}).WithOut(out)
+
+		tp.SetPrinter(tablePrinter)
+
+		printer = tablePrinter
 	case "template":
 		printer = printers.NewTemplatePrinter(viper.GetString("template")).WithOut(out)
 	default:

--- a/cmd/tableprinters/printer.go
+++ b/cmd/tableprinters/printer.go
@@ -1,0 +1,37 @@
+package tableprinters
+
+import (
+	"io"
+
+	"github.com/fi-ts/cloudctl/cmd/output"
+	"github.com/metal-stack/metal-lib/pkg/genericcli/printers"
+)
+
+type TablePrinter struct {
+	t *printers.TablePrinter
+	// TODO: we want to slowly migrate to the genericcli table printer
+	// after everything was shifted to this package we can remove the "oldPrinter"
+	oldPrinter printers.Printer
+}
+
+func New() *TablePrinter {
+	return &TablePrinter{
+		oldPrinter: output.New(),
+	}
+}
+
+func (t *TablePrinter) SetPrinter(printer *printers.TablePrinter) {
+	t.t = printer
+}
+
+func (t *TablePrinter) ToHeaderAndRows(data any, wide bool) ([]string, [][]string, error) {
+	// TODO: migrate old output package code to here
+	// switch d := data.(type) {
+	// default:
+	// 	return nil, nil,  t.oldPrinter.Print(data)
+	// }
+	//
+	// fallback to old printer for as long as the migration takes:
+	t.t.WithOut(io.Discard)
+	return nil, nil, t.oldPrinter.Print(data)
+}


### PR DESCRIPTION
This will allow us to slowly migrate to the genericcli table printer. It will fall back to the old output package printer implementation in case the printer does not match any known types.