### PR TITLE
throw an error if supplied pg restore timestamp is wrongly formatted

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -595,6 +595,12 @@ func (c *config) postgresRestore() error {
 	if err != nil {
 		return err
 	}
+
+	_, err = time.Parse("2006-01-02T15:04:05-07:00", timestamp)
+	if err != nil {
+		return fmt.Errorf("restore.timestamp cannot be parsed:%s, please provied a timestamp similar to e.g. 2021-12-07T15:28:00+01:00", timestamp)
+	}
+
 	pcsr := &models.V1PostgresRestoreRequest{
 		SourceID:    &srcID,
 		Description: desc,

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -598,7 +598,7 @@ func (c *config) postgresRestore() error {
 
 	_, err = time.Parse("2006-01-02T15:04:05-07:00", timestamp)
 	if err != nil {
-		return fmt.Errorf("restore.timestamp cannot be parsed:%s, please provied a timestamp similar to e.g. 2021-12-07T15:28:00+01:00", timestamp)
+		return fmt.Errorf("restore.timestamp cannot be parsed:%s, please provide a timestamp similar to e.g. 2021-12-07T15:28:00+01:00", timestamp)
 	}
 
 	pcsr := &models.V1PostgresRestoreRequest{


### PR DESCRIPTION
The current version does not report invalid timestamps. Postgreslet does report it, but you have to dig through its logs on the k8s cluster, which is cumbersome. The better variant is to report the error directly to the user.