### PR TITLE
Use the same format for creating the (default) timestamp as for valid…

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -310,7 +310,7 @@ postgres=#
 
 	// Restore
 	postgresRestoreCmd.Flags().StringP("source-postgres-id", "", "", "if of the primary database")
-	postgresRestoreCmd.Flags().StringP("timestamp", "", time.Now().Format(time.RFC3339), "point-in-time to restore to")
+	postgresRestoreCmd.Flags().StringP("timestamp", "", time.Now().Format("2006-01-02T15:04:05-07:00"), "point-in-time to restore to")
 	postgresRestoreCmd.Flags().StringP("version", "", "", "postgres version of the database")
 	postgresRestoreCmd.Flags().StringP("description", "", "", "description of the database")
 	postgresRestoreCmd.Flags().StringP("partition", "", "", "partition where the database should be created. Changing the partition compared to the source database requires administrative privileges")


### PR DESCRIPTION
`RFC3339` will create timestamps with Zulu time 9e.g. `2025-02-13T10:12:53Z) when `UTC` or no timezone is configured.

Since Zulu time will not be accepted by the `postgresqls` CRD down the line, we already validate against a specific format. But we didn't use that format to create the default value.

This PR prevents the creation of an invalid default timestamp when `UTC` or no timezone at all is configured, which would already fail the client-side validation.