### PR TITLE
fix --for-client=minio output for newer mc versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ the command: `cloudctl s3 describe --for-client minio|s3cmd` will echo the requi
 
 ```bash
 $ cloudctl s3 describe --for-client minio --id test --partition=fel-wps101 --project=4fe217b4-3b3d-413e-87fc-fb89054cc70c
-mc config host add test https://s3.test-01-fel-wps101.somedomain.example <your access key> <your secret key>
+mc alias set test https://s3.test-01-fel-wps101.somedomain.example <your access key> <your secret key>
 
 $ mc mb test/testbucket
 Bucket created successfully `test/testbucket`.

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -180,7 +180,7 @@ func (c *config) s3Describe() error {
 	switch client {
 	case "":
 	case "minio":
-		fmt.Printf("mc config host add %s %s %s %s\n", *cfg.ID, *cfg.Endpoint, *cfg.Keys[0].AccessKey, *cfg.Keys[0].SecretKey)
+		fmt.Printf("mc alias set %s %s %s %s\n", *cfg.ID, *cfg.Endpoint, *cfg.Keys[0].AccessKey, *cfg.Keys[0].SecretKey)
 		return nil
 	case "s3cmd":
 		fmt.Printf(s3cmdTemplate, *cfg.Keys[0].AccessKey, *cfg.Endpoint, *cfg.Endpoint, *cfg.Keys[0].SecretKey)


### PR DESCRIPTION
Print `mc alias set` instead of `mc config host add`

Tested `mc alias set` with:
  - [x] RELEASE.2022-02-02
  - [x] RELEASE.2025-05-21
  
  Closes: https://github.com/fi-ts/cloudctl/issues/343