### PR TITLE
Add SHA512 checksums to local builds alongside existing MD5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ build:
 		github.com/fi-ts/cloudctl
 
 	md5sum bin/$(BINARY) > bin/$(BINARY).md5
+	sha512sum bin/$(BINARY) > bin/$(BINARY).sha512
 
 .PHONY: test
 test: build


### PR DESCRIPTION
The updater library (metal-stack/updater) looks for .sha512 release
assets to verify downloaded binaries. Previously only .md5 files were
generated, causing 404 errors during update check/do. Now both MD5 and
SHA512 checksums are produced by the build target and included in
release assets via the bin/cloudctl-* upload glob.