### PR TITLE
Add `cloudctl status` command to open status dashboard in browser

### DIFF
--- a/cmd/helper/helper.go
+++ b/cmd/helper/helper.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -154,6 +155,23 @@ func MustPrintKubernetesResource(in any) {
 func ClientNoAuth() runtime.ClientAuthInfoWriterFunc {
 	noAuth := func(_ runtime.ClientRequest, _ strfmt.Registry) error { return nil }
 	return runtime.ClientAuthInfoWriterFunc(noAuth)
+}
+
+func OpenBrowser(url string) error {
+	var cmd string
+	var args []string
+
+	switch goruntime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default:
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
 }
 
 func ExpandHomeDir(path string) (string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ func newRootCmd(cfg *config) *cobra.Command {
 	rootCmd.AddCommand(newIPCmd(cfg))
 	rootCmd.AddCommand(newBillingCmd(cfg))
 	rootCmd.AddCommand(newHealthCmd(cfg))
+	rootCmd.AddCommand(newStatusCmd(cfg))
 
 	return rootCmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const statusURL = "https://status.fits.cloud"
+const defaultStatusURL = "https://status.fits.cloud"
 
 func newStatusCmd(c *config) *cobra.Command {
 	statusCmd := &cobra.Command{
@@ -25,6 +25,8 @@ func newStatusCmd(c *config) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("no valid session found, please run `cloudctl login` first: %w", err)
 			}
+
+			statusURL := viper.GetString("status-url")
 
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
@@ -66,5 +68,8 @@ func newStatusCmd(c *config) *cobra.Command {
 			return nil
 		},
 	}
+
+	statusCmd.Flags().String("status-url", defaultStatusURL, "URL of the status page")
+
 	return statusCmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -40,7 +40,7 @@ func newStatusCmd(c *config) *cobra.Command {
 				ReadHeaderTimeout: 5 * time.Second,
 				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.Header().Set("Content-Type", "text/html; charset=utf-8")
-					fmt.Fprintf(w, `<!DOCTYPE html>
+					_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
 <html><body>
 <form id="f" method="POST" action="%s/auth/login">
 <input type="hidden" name="token" value="%s">
@@ -57,10 +57,10 @@ func newStatusCmd(c *config) *cobra.Command {
 
 			if err := helper.OpenBrowser(localURL); err != nil {
 				_ = srv.Shutdown(context.Background())
-				fmt.Fprintln(c.out, "Could not open browser automatically.")
-				fmt.Fprintf(c.out, "Please open %s manually (available for 3 seconds).\n", localURL)
+				fmt.Println("Could not open browser automatically.")
+				fmt.Printf("Please open %s manually (available for 3 seconds).\n", localURL)
 			} else {
-				fmt.Fprintln(c.out, "Opening status page in browser...")
+				fmt.Println("Opening status page in browser...")
 			}
 
 			_ = srv.Serve(listener)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"time"
 
 	"github.com/fi-ts/cloudctl/cmd/helper"
 	"github.com/fi-ts/cloudctl/pkg/api"
@@ -21,15 +26,42 @@ func newStatusCmd(c *config) *cobra.Command {
 				return fmt.Errorf("no valid session found, please run `cloudctl login` first: %w", err)
 			}
 
-			url := fmt.Sprintf("%s/auth/login?token=%s", statusURL, authContext.IDToken)
-
-			if err := helper.OpenBrowser(url); err != nil {
-				fmt.Fprintln(c.out, "Could not open browser. Please open this URL manually:")
-				fmt.Fprintln(c.out, url)
-				return nil
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				return fmt.Errorf("unable to start local server: %w", err)
 			}
 
-			fmt.Fprintln(c.out, "Opening status page in browser...")
+			port := listener.Addr().(*net.TCPAddr).Port
+			localURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+			srv := &http.Server{
+				ReadHeaderTimeout: 5 * time.Second,
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					fmt.Fprintf(w, `<!DOCTYPE html>
+<html><body>
+<form id="f" method="POST" action="%s/auth/login">
+<input type="hidden" name="token" value="%s">
+</form>
+<script>document.getElementById("f").submit();</script>
+</body></html>`, html.EscapeString(statusURL), html.EscapeString(authContext.IDToken))
+				}),
+			}
+
+			go func() {
+				time.Sleep(3 * time.Second)
+				_ = srv.Shutdown(context.Background())
+			}()
+
+			if err := helper.OpenBrowser(localURL); err != nil {
+				_ = srv.Shutdown(context.Background())
+				fmt.Fprintln(c.out, "Could not open browser automatically.")
+				fmt.Fprintf(c.out, "Please open %s manually (available for 3 seconds).\n", localURL)
+			} else {
+				fmt.Fprintln(c.out, "Opening status page in browser...")
+			}
+
+			_ = srv.Serve(listener)
 
 			return nil
 		},

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fi-ts/cloudctl/cmd/helper"
+	"github.com/fi-ts/cloudctl/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const statusURL = "https://status.fits.cloud"
+
+func newStatusCmd(c *config) *cobra.Command {
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "open the status page in the browser",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			authContext, err := api.GetAuthContext(viper.GetString("kubeconfig"))
+			if err != nil {
+				return fmt.Errorf("no valid session found, please run `cloudctl login` first: %w", err)
+			}
+
+			url := fmt.Sprintf("%s/auth/login?token=%s", statusURL, authContext.IDToken)
+
+			if err := helper.OpenBrowser(url); err != nil {
+				fmt.Fprintln(c.out, "Could not open browser. Please open this URL manually:")
+				fmt.Fprintln(c.out, url)
+				return nil
+			}
+
+			fmt.Fprintln(c.out, "Opening status page in browser...")
+
+			return nil
+		},
+	}
+	return statusCmd
+}


### PR DESCRIPTION
This is related to fi-ts/status#75.

When the user enters `cloudctl status` he is automatically logged in at the status page with his token.

Please note that OpenBrowser has been copied from metal-stack/metal-lib as it isn't exported there.

Used AI-Tools ✨

Generated-By: Claude-Code/Opus 4.6