### PR TITLE
switch to github.com/gizak/termui

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	ui "github.com/dcorbe/termui-dpc"
-	"github.com/dcorbe/termui-dpc/widgets"
 	"github.com/fi-ts/cloud-go/api/client"
 	"github.com/fi-ts/cloud-go/api/client/cluster"
 	"github.com/fi-ts/cloud-go/api/client/health"
@@ -22,6 +20,8 @@ import (
 	"github.com/fi-ts/cloud-go/api/models"
 	"github.com/fi-ts/cloudctl/cmd/helper"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
 	"github.com/google/go-cmp/cmp"
 	"github.com/metal-stack/metal-lib/pkg/cache"
 	"github.com/metal-stack/metal-lib/pkg/genericcli"

--- a/cmd/dashboard_test.go
+++ b/cmd/dashboard_test.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"testing"
 
-	"github.com/dcorbe/termui-dpc/widgets"
 	"github.com/fi-ts/cloud-go/api/models"
+	"github.com/gizak/termui/v3/widgets"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.26
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/dcorbe/termui-dpc v0.0.0-20211125210512-9d2673a82dd6
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/fi-ts/accounting-go v0.11.1
 	github.com/fi-ts/cloud-go v0.30.19
 	github.com/gardener/gardener v1.123.5
 	github.com/gardener/machine-controller-manager v0.58.0
+	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-openapi/runtime v0.29.2
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/go-playground/validator/v10 v10.30.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dblohm7/wingoes v0.0.0-20250822163801-6d8e6105c62d h1:QRKpU+9ZBDs62LyBfwhZkJdB5DJX2Sm3p4kUh7l1aA0=
 github.com/dblohm7/wingoes v0.0.0-20250822163801-6d8e6105c62d/go.mod h1:SUxUaAK/0UG5lYyZR1L1nC4AaYYvSSYTWQSH3FPcxKU=
-github.com/dcorbe/termui-dpc v0.0.0-20211125210512-9d2673a82dd6 h1:nsEZIUOZXRZj6zmCOmFm0UZvkNPFjhVgGj92xtTopVQ=
-github.com/dcorbe/termui-dpc v0.0.0-20211125210512-9d2673a82dd6/go.mod h1:F38Y6O63Huw+i2ivWm7MHwxZ18yKfwF3/VSoTpH3yZc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
@@ -161,6 +159,8 @@ github.com/gardener/machine-controller-manager v0.58.0/go.mod h1:TCU/KoudCMt2eV0
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/github/fakeca v0.1.0 h1:Km/MVOFvclqxPM9dZBC4+QE564nU4gz4iZ0D9pMw28I=
 github.com/github/fakeca v0.1.0/go.mod h1:+bormgoGMMuamOscx7N91aOuUST7wdaJ2rNjeohylyo=
+github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
+github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=


### PR DESCRIPTION
github.com/dcorbe/termui-dpc was more or less a fork of github.com/gizak/termui/v3/widgets

we can switch to github.com/gizak/termui/v3/widgets

Closes: https://github.com/fi-ts/cloudctl/issues/329