### PR TITLE
feat: add --browser flag to status command

### DIFF
--- a/cmd/helper/helper.go
+++ b/cmd/helper/helper.go
@@ -157,18 +157,22 @@ func ClientNoAuth() runtime.ClientAuthInfoWriterFunc {
 	return runtime.ClientAuthInfoWriterFunc(noAuth)
 }
 
-func OpenBrowser(url string) error {
+func OpenBrowser(url string, browser string) error {
 	var cmd string
 	var args []string
 
-	switch goruntime.GOOS {
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start"}
-	case "darwin":
-		cmd = "open"
-	default:
-		cmd = "xdg-open"
+	if browser != "" {
+		cmd = browser
+	} else {
+		switch goruntime.GOOS {
+		case "windows":
+			cmd = "cmd"
+			args = []string{"/c", "start"}
+		case "darwin":
+			cmd = "open"
+		default:
+			cmd = "xdg-open"
+		}
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -55,7 +55,9 @@ func newStatusCmd(c *config) *cobra.Command {
 				_ = srv.Shutdown(context.Background())
 			}()
 
-			if err := helper.OpenBrowser(localURL); err != nil {
+			browser := viper.GetString("browser")
+
+			if err := helper.OpenBrowser(localURL, browser); err != nil {
 				_ = srv.Shutdown(context.Background())
 				fmt.Println("Could not open browser automatically.")
 				fmt.Printf("Please open %s manually (available for 3 seconds).\n", localURL)
@@ -70,6 +72,7 @@ func newStatusCmd(c *config) *cobra.Command {
 	}
 
 	statusCmd.Flags().String("status-url", defaultStatusURL, "URL of the status page")
+	statusCmd.Flags().String("browser", "", "Browser to use (e.g. firefox, chromium, brave)")
 
 	return statusCmd
 }


### PR DESCRIPTION
Adds a `--browser` flag to `cloudctl status` to allow specifying
an alternative browser (e.g. `--browser firefox`). If no browser
is given, the system default browser is used.